### PR TITLE
Fix typing_extensions.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ cma =
     cma>=3.0.0
 qiskit =
     qiskit>=0.28, <0.34;python_version<'3.10'
-    qiskit>=0.34;python_version>='3.10'
+    qiskit>=0.34, <0.37;python_version>='3.10'
     symengine~=0.7
 qubo =
     dimod>=0.9.11

--- a/src/orquestra/opt/api/cost_function.py
+++ b/src/orquestra/opt/api/cost_function.py
@@ -2,11 +2,10 @@
 # © Copyright 2022 Zapata Computing Inc.
 ################################################################################
 """Interfaces related to cost functions."""
-from typing import Union
+from typing import Protocol, Union
 
 import numpy as np
 from orquestra.quantum.utils import ValueEstimate
-from typing_extensions import Protocol
 
 from .functions import (
     CallableStoringArtifacts,

--- a/src/orquestra/opt/api/functions.py
+++ b/src/orquestra/opt/api/functions.py
@@ -3,10 +3,19 @@
 ################################################################################
 """Protocols describing different kinds of functions."""
 from inspect import signature
-from typing import Any, Callable, NamedTuple, Optional, TypeVar, Union, cast
+from typing import (
+    Any,
+    Callable,
+    NamedTuple,
+    Optional,
+    Protocol,
+    TypeVar,
+    Union,
+    cast,
+    runtime_checkable,
+)
 
 import numpy as np
-from typing_extensions import Protocol, runtime_checkable
 
 T = TypeVar("T", covariant=True)
 S = TypeVar("S", contravariant=True)

--- a/src/orquestra/opt/api/save_conditions.py
+++ b/src/orquestra/opt/api/save_conditions.py
@@ -2,9 +2,7 @@
 # © Copyright 2022 Zapata Computing Inc.
 ################################################################################
 """Save conditions possible to use with recorder."""
-from typing import Any
-
-from typing_extensions import Protocol
+from typing import Any, Protocol
 
 
 class SaveCondition(Protocol):

--- a/src/orquestra/opt/convex.py
+++ b/src/orquestra/opt/convex.py
@@ -1,12 +1,11 @@
 ################################################################################
 # © Copyright 2022 Zapata Computing Inc.
 ################################################################################
-from typing import Optional, Tuple
+from typing import Optional, Protocol, Tuple, runtime_checkable
 
 import cvxpy as cp
 import numpy as np
 from scipy.optimize import LinearConstraint
-from typing_extensions import Protocol, runtime_checkable
 
 from .api import Optimizer
 

--- a/src/orquestra/opt/history/recorder.py
+++ b/src/orquestra/opt/history/recorder.py
@@ -3,9 +3,17 @@
 ################################################################################
 """Main implementation of the recorder."""
 import copy
-from typing import Any, Callable, Dict, Generic, List, NamedTuple, TypeVar, Union
-
-from typing_extensions import overload
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    List,
+    NamedTuple,
+    TypeVar,
+    Union,
+    overload,
+)
 
 from ..api.functions import (
     CallableStoringArtifacts,


### PR DESCRIPTION
## Description

After moving from Python 3.7 to 3.8 we can stop using `typing_extensions` and start using `typing` in some places. This PR makes appropriate changes.

## Please verify that you have completed the following steps

- [X] I have self-reviewed my code.
