### PR TITLE
Install all dependencies with dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,4 @@ github_actions:
 	python3 -m venv ${VENV_NAME} && \
 		${VENV_NAME}/bin/python3 -m pip install --upgrade pip && \
 		${VENV_NAME}/bin/python3 -m pip install ./orquestra-quantum && \
-		${VENV_NAME}/bin/python3 -m pip install -e '.[dev,all]'
+		${VENV_NAME}/bin/python3 -m pip install -e '.[dev]'

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ all =
     orquestra-opt[scikit-quant]
 dev =
     orquestra-python-dev
+    orquestra-opt[all]
 
 [flake8]
 ignore = E203,E266,F401,W605


### PR DESCRIPTION
## Description

The original intention was to use `pip install -e .[dev,all]` to install everything. However, we decided that it makes more sense that running `pip install -e .[dev]` would install all the dependencies so that we can go straight into development out of the box.


## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
