### PR TITLE
Use public properties of pauliterm

### DIFF
--- a/src/orquestra/opt/bqm/conversions.py
+++ b/src/orquestra/opt/bqm/conversions.py
@@ -73,7 +73,7 @@ def convert_paulisum_to_qubo(operator: PauliSum) -> BinaryQuadraticModel:
         coeff = term.coefficient.real
         if term.is_constant:
             offset = coeff
-        qubits = list(term._ops.keys())
+        qubits = sorted(term.qubits)
         if len(qubits) == 1:
             linear_terms[qubits[0]] = -coeff
         if len(term) == 2:

--- a/tests/orquestra/opt/problems/generators_test.py
+++ b/tests/orquestra/opt/problems/generators_test.py
@@ -46,4 +46,4 @@ class TestGetRandomIsingHamiltonian:
         # Then
         for term in hamiltonian.terms:
             # Each term must have at most `max_num_qubits_per_term` operators (qubits)
-            assert len(term._ops) <= max_num_qubits_per_term
+            assert len(term.operations) <= max_num_qubits_per_term

--- a/tests/orquestra/opt/problems/vertex_cover_test.py
+++ b/tests/orquestra/opt/problems/vertex_cover_test.py
@@ -170,7 +170,7 @@ class TestGetVertexCoverHamiltonian:
             edge_term = [
                 term
                 for term in pauli_sum.terms
-                if term._ops == {qubit_index1: "Z", qubit_index2: "Z"}
+                if term.operations == set([(qubit_index1, "Z"), (qubit_index2, "Z")])
             ][0]
             assert edge_term.coefficient == 1.25
 


### PR DESCRIPTION
## Description

I realized after Michał's comments in another PR that I've been using the private `_ops` property of pauli terms rather than the public `operations` property like intended by the api. So, I'm fixing it in this repo.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [ ] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
