### PR TITLE
ZQS 1271: Introduce intermediate recorder protocols

### DIFF
--- a/src/orquestra/opt/api/cost_function.py
+++ b/src/orquestra/opt/api/cost_function.py
@@ -5,7 +5,6 @@
 from typing import Protocol, Union
 
 import numpy as np
-from orquestra.quantum.utils import ValueEstimate
 
 from .functions import (
     CallableStoringArtifacts,

--- a/src/orquestra/opt/api/cost_function.py
+++ b/src/orquestra/opt/api/cost_function.py
@@ -17,7 +17,7 @@ from .functions import (
 class _CostFunction(Protocol):
     """Cost function transforming vectors from R^n to numbers or their estimates."""
 
-    def __call__(self, parameters: np.ndarray) -> Union[float, ValueEstimate]:
+    def __call__(self, parameters: np.ndarray) -> float:
         """Compute  value of the cost function for given parameters."""
         ...
 

--- a/src/orquestra/opt/api/functions.py
+++ b/src/orquestra/opt/api/functions.py
@@ -96,7 +96,7 @@ class FunctionWithGradientStoringArtifacts(NamedTuple):
     gradient: Callable[[np.ndarray], np.ndarray]
 
     def __call__(
-        self, params: np.ndarray, store_artifact: StoreArtifact = None
+        self, params: np.ndarray, store_artifact: Optional[StoreArtifact] = None
     ) -> float:
         return self.function(params, store_artifact)
 

--- a/src/orquestra/opt/api/functions.py
+++ b/src/orquestra/opt/api/functions.py
@@ -43,7 +43,7 @@ class CallableWithGradient(Protocol):
 class CallableStoringArtifacts(Protocol[S, T]):
     """A callable that stores artifacts."""
 
-    def __call__(self, params: S, store_artifact: Optional[StoreArtifact]) -> T:
+    def __call__(self, params: S, store_artifact: Optional[StoreArtifact] = None) -> T:
         pass
 
 

--- a/src/orquestra/opt/api/optimizer.py
+++ b/src/orquestra/opt/api/optimizer.py
@@ -11,8 +11,6 @@ from scipy.optimize import OptimizeResult
 from ..history.recorder import (
     AnyHistory,
     AnyRecorder,
-    ArtifactRecorder,
-    ArtifactRecorderWithGradient,
     RecorderFactory,
     SimpleRecorder,
     SimpleRecorderWithGradient,

--- a/src/orquestra/opt/api/optimizer.py
+++ b/src/orquestra/opt/api/optimizer.py
@@ -19,6 +19,7 @@ from ..history.recorder import (
 )
 from ..history.recorder import recorder as _recorder
 from . import CallableWithGradient, CostFunction
+from .cost_function import _CostFunction
 
 
 class Optimizer(ABC):
@@ -48,6 +49,8 @@ class Optimizer(ABC):
                 evaluations should be recorded.
         """
         cost_function = self._preprocess_cost_function(cost_function)
+        x: _CostFunction = self.recorder(cost_function)
+        print(x)
         if keep_history:
             cost_function = self.recorder(cost_function)
         return self._minimize(cost_function, initial_params, keep_history)
@@ -112,15 +115,11 @@ def construct_history_info(
 ) -> Dict[str, AnyHistory]:
     histories: Dict[str, AnyHistory] = {}
     if keep_history:
-        # TODO: When we upgraded to 3.8 use get_args on AnyRecorder instead
-        if isinstance(cost_function, ArtifactRecorder):
-            histories["history"] = cost_function.history
         if isinstance(cost_function, SimpleRecorder):
             histories["history"] = cost_function.history
-        if isinstance(cost_function, ArtifactRecorderWithGradient):
-            histories["gradient_history"] = cost_function.gradient.history
         if isinstance(cost_function, SimpleRecorderWithGradient):
             histories["gradient_history"] = cost_function.gradient.history
+
     else:
         histories["history"] = cast(AnyHistory, [])
     return histories
@@ -130,11 +129,12 @@ def extend_histories(
     cost_function: AnyRecorder, histories: Dict[str, List]
 ) -> Dict[str, List]:
     new_histories = construct_history_info(cost_function, True)
-    updated_histories = {"history": histories["history"] + new_histories["history"]}
+    updated_histories = {"history": [*histories["history"], *new_histories["history"]]}
     if hasattr(cost_function, "gradient"):
-        updated_histories["gradient_history"] = (
-            histories["gradient_history"] + new_histories["gradient_history"]
-        )
+        updated_histories["gradient_history"] = [
+            *histories["gradient_history"],
+            *new_histories["gradient_history"],
+        ]
     return updated_histories
 
 

--- a/src/orquestra/opt/history/recorder.py
+++ b/src/orquestra/opt/history/recorder.py
@@ -3,6 +3,7 @@
 ################################################################################
 """Main implementation of the recorder."""
 import copy
+from dataclasses import dataclass
 from typing import (
     Any,
     Callable,
@@ -10,10 +11,15 @@ from typing import (
     Generic,
     List,
     NamedTuple,
+    Protocol,
+    Sequence,
     TypeVar,
     Union,
     overload,
+    runtime_checkable,
 )
+
+import numpy as np
 
 from ..api.functions import (
     CallableStoringArtifacts,
@@ -24,8 +30,8 @@ from ..api.functions import (
 )
 from ..api.save_conditions import SaveCondition, always
 
-T = TypeVar("T")
-S = TypeVar("S")
+T = TypeVar("T", covariant=True)
+S = TypeVar("S", contravariant=True)
 
 NATIVE_RECORDER_ATTRIBUTES = (
     "predicate",
@@ -46,21 +52,20 @@ class ArtifactCollection(dict):
     forced: bool = False
 
 
-class HistoryEntryWithArtifacts(NamedTuple):
-    """A history entry enhanced with artifacts."""
-
-    call_number: int
-    params: Any
-    value: Any
-    artifacts: Dict[str, Any]
-
-
-class HistoryEntry(NamedTuple):
+@dataclass
+class HistoryEntry:
     """A history entry storing call number, parameters and target function value."""
 
     call_number: int
     params: Any
     value: Any
+
+
+@dataclass
+class HistoryEntryWithArtifacts(HistoryEntry):
+    """A history entry enhanced with artifacts."""
+
+    artifacts: Dict[str, Any]
 
 
 def copy_recorder(recorder_to_copy):
@@ -87,7 +92,105 @@ def deepcopy_recorder(recorder_to_copy, memo):
     return recorder_copy
 
 
-class SimpleRecorder(Generic[S, T]):
+@runtime_checkable
+class SimpleRecorder(Protocol[S, T]):
+    """Protocol representing recorder with basic functionalities.
+
+    Simple recorders have target and history attributes. They forward calls made
+    to them to the target.
+
+    The target property is exposed so that clients have access to an unwrapped
+    callable in case they need to make a call that is not recorder.
+
+    Note that this recorder is structurally a base protocol for any other
+    types of recorders. In other words  every recorder is at least a SimpleRecorder.
+    """
+
+    @property
+    def target(self) -> Callable[[S], T]:
+        pass
+
+    def __call__(self, parameters: S) -> T:
+        pass
+
+    @property
+    def history(self) -> Sequence[HistoryEntry]:
+        pass
+
+
+@runtime_checkable
+class SimpleRecorderWithGradient(Protocol):
+    """A protocol representing recorders wrapping functions with gradients.
+
+    Aside the attributes of SimpleRecorder, this recorder also has a gradient
+    attribute which itself is a recorder (and hence, has its own `history`
+    attribute.
+
+    Note that this protocol is not generic, because we only define gradients
+    for functions from R^N to R (which translates to Callable[[ndarray], float]).
+    """
+
+    @property
+    def target(self) -> Callable[[np.ndarray], float]:
+        pass
+
+    def __call__(self, parameters: np.ndarray) -> float:
+        pass
+
+    @property
+    def gradient(self) -> SimpleRecorder[np.ndarray, np.ndarray]:
+        pass
+
+    @property
+    def history(self) -> Sequence[HistoryEntry]:
+        pass
+
+
+class ArtifactRecorder(Protocol[S, T]):
+    """A protocol representing recorders that can store artifacts.
+
+    It is like simple recorder, but its target has to be a CallableStoringArtifacts.
+    It also stores a list of HistoryEntryWithArtifact objects instead of usual
+    HistoryEntry ones.
+    """
+
+    @property
+    def target(self) -> CallableStoringArtifacts[S, T]:
+        pass
+
+    def __call__(self, parameters: S) -> T:
+        pass
+
+    @property
+    def history(self) -> Sequence[HistoryEntryWithArtifacts]:
+        pass
+
+
+class ArtifactRecorderWithGradient(Protocol):
+    """Protocol for recorders wrapping functions having gradient and storing artifacts.
+
+    It is the most narrow type of recorder, combining both the
+    SimpleReorderWithGradient and Artifact recorder. Hence, this recorder is
+    non-generic and stores history entries with artifacts.
+    """
+
+    @property
+    def target(self) -> CallableWithGradientStoringArtifacts:
+        pass
+
+    def __call__(self, parameters: np.ndarray) -> float:
+        pass
+
+    @property
+    def gradient(self) -> SimpleRecorder[np.ndarray, np.ndarray]:
+        pass
+
+    @property
+    def history(self) -> Sequence[HistoryEntryWithArtifacts]:
+        pass
+
+
+class SimpleRecorderImpl(Generic[S, T]):
     """A basic recorder that stores history entries.
 
     Args:
@@ -133,7 +236,7 @@ class SimpleRecorder(Generic[S, T]):
     __deepcopy__ = deepcopy_recorder
 
 
-class SimpleRecorderWithGradient(SimpleRecorder):
+class SimpleRecorderWithGradientImpl(SimpleRecorderImpl):
     """A recorder saving history entries that works with callables with gradient.
 
     Except having `gradient` attribute, this recorder is the same as `SimpleRecorder`.
@@ -144,7 +247,7 @@ class SimpleRecorderWithGradient(SimpleRecorder):
         self.gradient = recorder(target.gradient, save_condition)
 
 
-class ArtifactRecorder(Generic[S, T]):
+class ArtifactRecorderImpl(Generic[S, T]):
     """A recorder saving history entries with artifacts.
 
     Parameters to initializer are the same as for `SimpleRecorder`,
@@ -185,7 +288,7 @@ class ArtifactRecorder(Generic[S, T]):
     __deepcopy__ = deepcopy_recorder
 
 
-class ArtifactRecorderWithGradient(ArtifactRecorder):
+class ArtifactRecorderWithGradientImpl(ArtifactRecorderImpl):
     """A recorder storing history entries with artifacts supporting callables with
     gradient.
     """
@@ -222,7 +325,7 @@ def store_artifact(artifacts) -> StoreArtifact:
 
 AnyRecorder = Union[SimpleRecorder, ArtifactRecorder]
 RecorderFactory = Callable[[Callable], AnyRecorder]
-AnyHistory = Union[List[HistoryEntry], List[HistoryEntryWithArtifacts]]
+AnyHistory = Union[Sequence[HistoryEntry], Sequence[HistoryEntryWithArtifacts]]
 
 
 @overload
@@ -280,10 +383,10 @@ def recorder(function, save_condition: SaveCondition = always):
     with_gradient = isinstance(function, CallableWithGradient)
 
     if with_artifacts and with_gradient:
-        return ArtifactRecorderWithGradient(function, save_condition)
+        return ArtifactRecorderWithGradientImpl(function, save_condition)
     elif with_artifacts:
-        return ArtifactRecorder(function, save_condition)
+        return ArtifactRecorderImpl(function, save_condition)
     elif with_gradient:
-        return SimpleRecorderWithGradient(function, save_condition)
+        return SimpleRecorderWithGradientImpl(function, save_condition)
     else:
-        return SimpleRecorder(function, save_condition)
+        return SimpleRecorderImpl(function, save_condition)

--- a/src/orquestra/opt/history/recorder.py
+++ b/src/orquestra/opt/history/recorder.py
@@ -10,7 +10,6 @@ from typing import (
     Dict,
     Generic,
     List,
-    NamedTuple,
     Protocol,
     Sequence,
     TypeVar,

--- a/src/orquestra/opt/optimizers/basin_hopping.py
+++ b/src/orquestra/opt/optimizers/basin_hopping.py
@@ -1,7 +1,7 @@
 ################################################################################
 # © Copyright 2022 Zapata Computing Inc.
 ################################################################################
-from typing import Callable, Union
+from typing import Callable, Optional, Union
 
 import numpy as np
 import scipy.optimize
@@ -60,7 +60,7 @@ class BasinHoppingOptimizer(Optimizer):
     def _minimize(
         self,
         cost_function: Union[CallableWithGradient, Callable],
-        initial_params: np.ndarray = None,
+        initial_params: Optional[np.ndarray] = None,
         keep_history: bool = False,
     ):
         """

--- a/src/orquestra/opt/optimizers/scipy_optimizer.py
+++ b/src/orquestra/opt/optimizers/scipy_optimizer.py
@@ -27,7 +27,7 @@ class ScipyOptimizer(Optimizer):
             None,
         ] = None,
         options: Optional[Dict] = None,
-        recorder: RecorderFactory = _recorder,ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss
+        recorder: RecorderFactory = _recorder,
     ):
         """
         Integration with scipy optimizers. Documentation for this module is minimal,

--- a/src/orquestra/opt/optimizers/scipy_optimizer.py
+++ b/src/orquestra/opt/optimizers/scipy_optimizer.py
@@ -53,7 +53,7 @@ class ScipyOptimizer(Optimizer):
     def _minimize(
         self,
         cost_function: Union[CallableWithGradient, Callable],
-        initial_params: np.ndarray = None,
+        initial_params: Optional[np.ndarray] = None,
         keep_history: bool = False,
     ):
         """


### PR DESCRIPTION
## Description

On several occasions, we had problems with type hierarchy related to recorders. This was especially noticeable when we tried to fix other typing problems, like making `store_artifact` accept a default value of `None`, which triggered "overlapping signatures" errors for the `recorder` function. This PR should stop such problems from occurring, by decoupling recorder protocols from their implementations. By using structural subtyping we avoid constructing "diamond shaped" inheritance hierarchy, while still maintaining compatibility of return types in different overloads of `recorder` function.

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
