### PR TITLE
chore: Remove Python 3.11 upper bound

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
     # Run jobs for a couple of Python versions.
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.9", "3.10", "3.11"]
 
     name: TestCoverage - Python ${{ matrix.python }}
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,4 +35,10 @@ jobs:
           repository: zapatacomputing/orquestra-quantum
           path: orquestra-quantum
 
+      - name: Get orquestra-qiskit
+        uses: actions/checkout@v2
+        with:
+          repository: zapatacomputing/orquestra-qiskit
+          path: orquestra-qiskit
+
       - uses: ./subtrees/z_quantum_actions/actions/coverage

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -22,7 +22,7 @@ jobs:
     # Run jobs for a couple of Python versions.
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10"]
+        python: ["3.9", "3.10", "3.11"]
 
     name: Style - Python ${{ matrix.python }}
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -35,5 +35,11 @@ jobs:
           repository: zapatacomputing/orquestra-quantum
           path: orquestra-quantum
 
+      - name: Get orquestra-qiskit
+        uses: actions/checkout@v2
+        with:
+          repository: zapatacomputing/orquestra-qiskit
+          path: orquestra-qiskit
+
       # Installs project, checks codestyle
       - uses: ./subtrees/z_quantum_actions/actions/style

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,5 @@ github_actions:
 	python3 -m venv ${VENV_NAME} && \
 		${VENV_NAME}/bin/python3 -m pip install --upgrade pip && \
 		${VENV_NAME}/bin/python3 -m pip install ./orquestra-quantum && \
+		${VENV_NAME}/bin/python3 -m pip install ./orquestra-qiskit && \
 		${VENV_NAME}/bin/python3 -m pip install -e '.[dev]'

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ include_package_data = True
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >=3.8,!=3.9.7,<3.11
+python_requires = >=3.9,!=3.9.7
 
 install_requires =
     orquestra-quantum


### PR DESCRIPTION
## Description

In order to allow Python versions newer than 3.10 we need to remove the upper bound.

This PR:
- allows Orquestra Opt to work on 3.11 and later


## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [x] I have updated documentation.
